### PR TITLE
fix: :memo: update the "edit this page on github" link

### DIFF
--- a/doc/.vitepress/config.ts
+++ b/doc/.vitepress/config.ts
@@ -67,7 +67,7 @@ export default defineConfig({
     ],
 
     editLink: {
-      pattern: "https://github.com/vuejs/vitepress/edit/main/docs/:path",
+      pattern: "https://github.com/rajpatelbot/SundarUI/edit/master/doc/:path",
       text: "Edit this page on GitHub",
     },
 


### PR DESCRIPTION
Fixes #15 

changed the username and repo name in the edit link.
Also changed the branch name from `main` to `master` as this project has it's main branch `master`

Now the `edit this page on github` link opens the new window of the documentation page using the `:path` variable